### PR TITLE
Add GitHub Action for npm install && npm run build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: npm install && npm run build
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix for #16 

Notes:
- Runs `npm install` and `npm run build` on `pull_request` and `push` to `main`.
- Basic CI to make sure that changes are `build`able
- [Sample successful workflow](https://github.com/native-land-digital/next-nld/actions/runs/11097874450/job/30829849689)
- The dev (not production) `DATABASE_URL` and `DIRECT_URL` are now added to this repository as [GitHub Actions secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository)
  - **Note:** if these ever have to be updated, they *don't* take double-quotes
  - eg. `postgres://postgres1234...` instead of `"postgres://postgres1234..."`

FYI:
- `npm run build` actually runs these 3 scripts: `prisma generate && prisma migrate deploy && next build` 
- This means that this workflow is going to run a migration to the dev database via `prisma migrate` 