### PR TITLE
Updated docker compose build file

### DIFF
--- a/Dockerfile-db
+++ b/Dockerfile-db
@@ -23,5 +23,5 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /docker-entrypoint-initdb.d
-COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
-COPY ./update-postgis.sh /usr/local/bin
+COPY ./db/initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
+COPY ./db/update-postgis.sh /usr/local/bin


### PR DESCRIPTION
This PR is minor update to fix two `docker compose build` errors:

1. scriptdir
```
 => ERROR [db 5/5] COPY ./update-postgis.sh /usr/local/bin                       0.0s
------
 > [db 5/5] COPY ./update-postgis.sh /usr/local/bin:
------
failed to solve: failed to compute cache key: failed to calculate checksum of ref 221034cd-e1f9-4660-afc3-352df9b4d310::ymvavflpct4kaw00bw1k90b4e: "/update-postgis.sh": not found
```

3. postgis version
```
4.471 3.5.2+dfsg-1.pgdg110+1 - postgresql-16-postgis (= ) 
4.471 Reverse Provides: 
4.490 Reading package lists...
4.968 Building dependency tree...
5.090 Reading state information...
5.208 E: Version '3.5.0+dfsg-1.pgdg110+1' for 'postgresql-16-postgis-3' was not found
------
```